### PR TITLE
セッション機能の追加とエンドポイントにapiの追加

### DIFF
--- a/client/src/domain/user.ts
+++ b/client/src/domain/user.ts
@@ -16,3 +16,9 @@ export const UserSchema = z.object({
 
 export type User = z.infer<typeof UserSchema>;
 export const userAtom = atom<User>();
+
+
+export type SessionData = {
+  uuid: string;
+  email: string;
+}

--- a/client/src/feature/menubar/hooks/checksession.ts
+++ b/client/src/feature/menubar/hooks/checksession.ts
@@ -1,0 +1,26 @@
+// hooks/useAuth.ts
+import {SessionData, User} from '@/domain/user';
+import {useCallback} from "react";
+import {apiClient} from "@/utils/client";
+
+export const useAuth = () => {
+    const checkSession = useCallback(async () => {
+        try {
+            const res = await apiClient.get("/api/session");
+            const session = res.data;
+            const userData: SessionData = {
+                uuid: session.user_id,
+                email: session.email,
+            };
+            console.log(userData)
+        } catch (error) {
+            console.error('Session check failed:', error);
+        } finally {
+            console.log("set user")
+        }
+    }, []);
+
+    return {
+        checkSession,
+    };
+};

--- a/client/src/feature/menubar/hooks/useAuth.ts
+++ b/client/src/feature/menubar/hooks/useAuth.ts
@@ -6,7 +6,7 @@ import {apiClient} from "@/utils/client";
 export const useAuth = () => {
     const checkSession = useCallback(async () => {
         try {
-            const res = await apiClient.get("/api/session");
+            const res = await apiClient.get("/session");
             const session = res.data;
             const userData: SessionData = {
                 uuid: session.user_id,
@@ -20,7 +20,16 @@ export const useAuth = () => {
         }
     }, []);
 
+    const signout = useCallback( async () => {
+        try {
+            await apiClient.get("signout")
+        } catch (error) {
+            console.log('Signout failed:', error)
+        }
+    }, []);
+
     return {
         checkSession,
+        signout
     };
 };

--- a/client/src/feature/menubar/index.tsx
+++ b/client/src/feature/menubar/index.tsx
@@ -20,12 +20,13 @@ import { useAtom } from "jotai/index";
 import { Calendar, CreditCard, LogOut, Settings, User } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import React from "react";
+import React, {useEffect} from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { MailIcon } from "./components/mail";
 import Search from "./components/search";
 import style from "./index.module.scss";
+import {useAuth} from "@/feature/menubar/hooks/checksession";
 
 const mockData = [
   { label: "東京大学" },
@@ -47,6 +48,11 @@ export const Menubar = () => {
   let accountName = "";
   let accountIcon = "https://github.com/shadcn.png";
   let settingURI = "";
+  const {checkSession } = useAuth();
+  useEffect(() => {
+    checkSession();
+  }, [checkSession]);
+
   const [currentAccountType, setCurrentAccountType] = useAtom(accountTypeAtom);
   const [currentUser, setCurrentUser] = useAtom(userAtom);
   const [currentCommunity, setCurrentCommunity] = useAtom(communityAtom);

--- a/client/src/feature/menubar/index.tsx
+++ b/client/src/feature/menubar/index.tsx
@@ -26,7 +26,7 @@ import { toast } from "sonner";
 import { MailIcon } from "./components/mail";
 import Search from "./components/search";
 import style from "./index.module.scss";
-import {useAuth} from "@/feature/menubar/hooks/checksession";
+import {useAuth} from "@/feature/menubar/hooks/useAuth";
 
 const mockData = [
   { label: "東京大学" },
@@ -48,7 +48,7 @@ export const Menubar = () => {
   let accountName = "";
   let accountIcon = "https://github.com/shadcn.png";
   let settingURI = "";
-  const {checkSession } = useAuth();
+  const {checkSession ,signout} = useAuth();
   useEffect(() => {
     checkSession();
   }, [checkSession]);
@@ -72,6 +72,7 @@ export const Menubar = () => {
   }
 
   const onClickSignout = () => {
+    signout();
     setCurrentUser(undefined);
     setCurrentCommunity(undefined);
     setCurrentAccountType("not");
@@ -112,10 +113,10 @@ export const Menubar = () => {
               </DropdownMenuItem>
             )}
             <DropdownMenuItem asChild>
-              <Link href="/signin/user" onClick={onClickSignout}>
+              <button onClick={onClickSignout}>
                 <LogOut />
                 <span>signout</span>
-              </Link>
+              </button>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/server/infrastructure/middleware/cors.go
+++ b/server/infrastructure/middleware/cors.go
@@ -12,6 +12,7 @@ func CORS() gin.HandlerFunc {
 		c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS")
 		c.Header("Access-Control-Allow-Headers", "Content-Type, Accept")
 		c.Header("Access-Control-Allow-Credentials", "true")
+		c.Header("Access-Control-Expose-Headers", "Set-Cookie")
 		c.Header("Access-Control-Max-Age", "100")
 
 		if c.Request.Method == http.MethodOptions {

--- a/server/interfaces/handlers/auth_community_handler.go
+++ b/server/interfaces/handlers/auth_community_handler.go
@@ -84,5 +84,28 @@ func (h *communityHandler) SignIn(ctx *gin.Context) {
 		return
 	}
 
+	// セッションの取得
+	session, err := h.store.Get(ctx.Request, "session-name")
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Session error"})
+		return
+	}
+
+	session.Values["user_id"] = uuid // ユーザーIDを保存
+	session.Values["account_type"] = "user"
+	// セッションの設定を調整
+	session.Options = &sessions.Options{
+		Path:     "/",
+		MaxAge:   3600 * 24, // セッションの有効期限（適宜調整）
+		HttpOnly: true,
+		Secure:   true, // HTTPSが有効な環境で使用
+		SameSite: http.SameSiteNoneMode,
+	}
+
+	if err := session.Save(ctx.Request, ctx.Writer); err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save session"})
+		return
+	}
+
 	ctx.JSON(http.StatusOK, gin.H{"message": "login in successful", "uuid": uuid})
 }

--- a/server/interfaces/handlers/auth_handler.go
+++ b/server/interfaces/handlers/auth_handler.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"fmt"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/gorilla/sessions"
 	"github.com/jphacks/os_2403/usecase"
 	"net/http"
@@ -16,6 +18,7 @@ type authUserHandler struct {
 type IAuthHandler interface {
 	SignUp(ctx *gin.Context)
 	SignIn(ctx *gin.Context)
+	CheckSession(ctx *gin.Context)
 }
 
 type (
@@ -38,33 +41,34 @@ func (h *authUserHandler) SignUp(ctx *gin.Context) {
 	}
 
 	// SignInメソッドを呼び出す
-	if err := h.authUsecase.SignUp(ctx, request); err != nil {
+	uuid, err := h.authUsecase.SignUp(ctx, request)
+	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	//// セッションの取得
-	//session, err := h.store.Get(ctx.Request, "session-name")
-	//if err != nil {
-	//	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Session error"})
-	//	return
-	//}
-	//
-	//// セッションの設定を調整
-	//session.Options = &sessions.Options{
-	//	Path:     "/",
-	//	MaxAge:   100 * 1, // セッションの有効期限（適宜調整）
-	//	HttpOnly: true,
-	//	Secure:   true, // HTTPSが有効な環境で使用
-	//	SameSite: http.SameSiteNoneMode,
-	//}
+	// セッションの取得
+	session, err := h.store.Get(ctx.Request, "session-name")
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Session error"})
+		return
+	}
 
-	//if err := session.Save(ctx.Request, ctx.Writer); err != nil {
-	//	ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save session"})
-	//	return
-	//}
+	session.Values["user_id"] = uuid // ユーザーIDを保存
+	session.Values["account_type"] = "user"
+	// セッションの設定を調整
+	session.Options = &sessions.Options{
+		Path:     "/",
+		MaxAge:   3600 * 24, // セッションの有効期限（適宜調整）
+		HttpOnly: true,
+		Secure:   true, // HTTPSが有効な環境で使用
+		SameSite: http.SameSiteNoneMode,
+	}
 
-	//h.sessionsUsecase.SignIn(ctx, )
+	if err := session.Save(ctx.Request, ctx.Writer); err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save session"})
+		return
+	}
 
 	ctx.JSON(http.StatusCreated, gin.H{"message": "sign in successful"})
 }
@@ -76,11 +80,6 @@ func (h *authUserHandler) SignIn(ctx *gin.Context) {
 		return
 	}
 
-	// SignInメソッドを呼び出す
-	//if err := h.authUsecase.SignIn(ctx, request); err != nil {
-	//	ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-	//	return
-	//}
 	uuid, err := h.authUsecase.SignIn(ctx, request)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -88,4 +87,33 @@ func (h *authUserHandler) SignIn(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, gin.H{"message": "login in successful", "uuid": uuid})
+}
+
+func (h *authUserHandler) CheckSession(c *gin.Context) {
+	fmt.Println("check session request")
+	fmt.Println(c.Request)
+	session, err := h.store.Get(c.Request, "session-name")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Session error"})
+		return
+	}
+
+	fmt.Printf("session: %+v\\n", session)
+	fmt.Printf("session.Values keys: %+v\\n", session.Values["user_id"])
+
+	if auth, ok := session.Values["user_id"].(uuid.UUID); !ok || auth.String() == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	// ユーザー情報をレスポンスとして返す
+	response := map[string]interface{}{
+		"user_id":      session.Values["user_id"],
+		"account_type": session.Values["account_type"],
+		"status":       "authenticated",
+	}
+
+	fmt.Println("respons: %+v\n", response)
+
+	c.JSON(http.StatusOK, response)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -77,7 +77,9 @@ func main() {
 
 	router.POST("/api/user/signin", authUserHandler.SignIn)
 	router.POST("/api/user/signup", authUserHandler.SignUp)
+
 	router.GET("/api/session", authUserHandler.CheckSession)
+	router.GET("/api/signout", authUserHandler.SignOut)
 
 	router.GET("/api/user/:uuid", userHandler.FindByID)
 	router.PUT("/api/user/:uuid", userHandler.Update)

--- a/server/main.go
+++ b/server/main.go
@@ -2,9 +2,11 @@
 package main
 
 import (
+	"encoding/gob"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/google/uuid"
 	"github.com/gorilla/sessions"
 	"github.com/joho/godotenv"
 	"github.com/jphacks/os_2403/infrastructure/dao"
@@ -29,6 +31,8 @@ func main() {
 	fmt.Println(db)
 
 	// 初期化はinfra(persistence)->domain/service->usecase->handlerの順番で行うようにしよう
+	godotenv.Load()
+	gob.Register(uuid.UUID{})
 
 	store := sessions.NewCookieStore([]byte(os.Getenv("SESSION_KEY")))
 
@@ -69,33 +73,34 @@ func main() {
 	//authMiddleware := middleware.NewAuthMiddleware(store)
 	router.Use(middleware.CORS())
 
-	router.GET("/health", health)
+	router.GET("/api/health", health)
 
-	router.POST("/user/signin", authUserHandler.SignIn)
-	router.POST("/user/signup", authUserHandler.SignUp)
+	router.POST("/api/user/signin", authUserHandler.SignIn)
+	router.POST("/api/user/signup", authUserHandler.SignUp)
+	router.GET("/api/session", authUserHandler.CheckSession)
 
-	router.GET("/user/:uuid", userHandler.FindByID)
-	router.PUT("/user/:uuid", userHandler.Update)
+	router.GET("/api/user/:uuid", userHandler.FindByID)
+	router.PUT("/api/user/:uuid", userHandler.Update)
 
-	router.POST("/community/signin", authCommunityHandler.SignIn)
-	router.POST("/community/signup", authCommunityHandler.SignUp)
+	router.POST("/api/community/signin", authCommunityHandler.SignIn)
+	router.POST("/api/community/signup", authCommunityHandler.SignUp)
 
-	router.GET("/community/:uuid", communityHandler.FindById)
-	router.PUT("/community/:uuid", communityHandler.Update)
+	router.GET("/api/community/:uuid", communityHandler.FindById)
+	router.PUT("/api/community/:uuid", communityHandler.Update)
 
-	router.GET("/tag", tagHandler.GetRandom)
+	router.GET("/api/tag", tagHandler.GetRandom)
 
-	router.GET("/getscoutdetail", scoutListHandler.GetCommunityDetailByScoutList)
-	router.POST("/createscout", scoutListHandler.CreateScouts)
-	router.PUT("/changescoutstatus", scoutListHandler.ChangeStatus)
-	router.GET("/getmessageuser", scoutListHandler.GetMessageUser)
+	router.GET("/api/getscoutdetail", scoutListHandler.GetCommunityDetailByScoutList)
+	router.POST("/api/createscout", scoutListHandler.CreateScouts)
+	router.PUT("/api/changescoutstatus", scoutListHandler.ChangeStatus)
+	router.GET("/api/getmessageuser", scoutListHandler.GetMessageUser)
 
-	router.GET("/getevent", eventHandler.GetAllEvents)
-	router.POST("/createdevent", eventHandler.CreateEvent)
-	router.PUT("/updataevent", eventHandler.UpdateEvent)
+	router.GET("/api/getevent", eventHandler.GetAllEvents)
+	router.POST("/api/createdevent", eventHandler.CreateEvent)
+	router.PUT("/api/updataevent", eventHandler.UpdateEvent)
 
-	router.GET("/ws/chat/:room_id", chatHandler.HandleWebSocket)
-	router.GET("/messages/:room_id", chatHandler.GetMessages) // チャット履歴取得用
+	router.GET("/api/ws/chat/:room_id", chatHandler.HandleWebSocket)
+	router.GET("/api/messages/:room_id", chatHandler.GetMessages) // チャット履歴取得用
 
 	log.Fatal(http.ListenAndServe(":80", router))
 }

--- a/server/usecase/auth_community_usecase.go
+++ b/server/usecase/auth_community_usecase.go
@@ -28,7 +28,7 @@ type InputCommunitySignIn struct {
 }
 
 type IAuthCommunityUsecase interface {
-	SignUp(ctx context.Context, input InputCommunitySignUp) error
+	SignUp(ctx context.Context, input InputCommunitySignUp) (uuid.UUID, error)
 	SignIn(ctx context.Context, input InputCommunitySignIn) (uuid.UUID, error)
 }
 
@@ -48,7 +48,7 @@ func NewAuthCommunityUseCase(community repositories.ICommunityRepository, sessio
 	}
 }
 
-func (u *authCommunityUsecase) SignUp(ctx context.Context, input InputCommunitySignUp) error {
+func (u *authCommunityUsecase) SignUp(ctx context.Context, input InputCommunitySignUp) (uuid.UUID, error) {
 	fmt.Println("usecase")
 	fmt.Println(input)
 
@@ -74,7 +74,7 @@ func (u *authCommunityUsecase) SignUp(ctx context.Context, input InputCommunityS
 	// パスワードをハッシュ化
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(input.Password), bcrypt.DefaultCost)
 	if err != nil {
-		return fmt.Errorf("failed to hash password: %v", err)
+		return uuid.Nil, fmt.Errorf("failed to hash password: %v", err)
 	}
 
 	fmt.Println(input.Range)
@@ -96,10 +96,10 @@ func (u *authCommunityUsecase) SignUp(ctx context.Context, input InputCommunityS
 	fmt.Println(community)
 
 	if err := u.communityRepo.Create(ctx, community); err != nil {
-		return err
+		return uuid.Nil, err
 	}
 
-	return nil
+	return community.UUID, nil
 }
 
 func (u *authCommunityUsecase) SignIn(ctx context.Context, input InputCommunitySignIn) (uuid.UUID, error) {

--- a/server/usecase/auth_usecase.go
+++ b/server/usecase/auth_usecase.go
@@ -27,7 +27,7 @@ type InputSignIn struct {
 }
 
 type IAuthUsecase interface {
-	SignUp(ctx context.Context, input InputSignUp) error
+	SignUp(ctx context.Context, input InputSignUp) (uuid.UUID, error)
 	SignIn(ctx context.Context, input InputSignIn) (uuid.UUID, error)
 }
 
@@ -47,7 +47,7 @@ func NewAuthUserUseCase(userRepo repositories.IUserRepository, sessionRepo repos
 	}
 }
 
-func (u *authUsecase) SignUp(ctx context.Context, input InputSignUp) error {
+func (u *authUsecase) SignUp(ctx context.Context, input InputSignUp) (uuid.UUID, error) {
 	fmt.Println("usecase")
 	fmt.Println(input)
 	var user *models.User
@@ -72,7 +72,7 @@ func (u *authUsecase) SignUp(ctx context.Context, input InputSignUp) error {
 	// パスワードをハッシュ化
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(input.Password), bcrypt.DefaultCost)
 	if err != nil {
-		return fmt.Errorf("failed to hash password: %v", err)
+		return uuid.Nil, fmt.Errorf("failed to hash password: %v", err)
 	}
 
 	// 新規ユーザーの作成
@@ -91,10 +91,10 @@ func (u *authUsecase) SignUp(ctx context.Context, input InputSignUp) error {
 	fmt.Println(user)
 
 	if err := u.userRepo.Create(ctx, user); err != nil {
-		return err
+		return uuid.Nil, err
 	}
 
-	return nil
+	return user.UUID, nil
 }
 
 func (u *authUsecase) SignIn(ctx context.Context, input InputSignIn) (uuid.UUID, error) {


### PR DESCRIPTION
# SignUpの機能時にセッションを作成し、クッキーをクライアントに保存する。

### エンドポイント(POST)
```
/api/user/signup
/api/community/signup
```

### クッキーの保存の型
```
session-name=hogehoge
```


# クッキーを使用してUUIDを取り出す機能

### エンドポイント(GET)
```
/api/session
```

### レスポンスの型
```
{account_type: "community", status: "authenticated", user_id: "28afad4c-ae42-4eaf-bdf8-65e2bea226fd"}
```


# Signout機能の追加

### エンドポイント(GET)
```
/api/signout
```